### PR TITLE
Fixes for id attar + add click attr for callback.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,11 @@ Add the chart module as a dependency to your application module:
 
 Apply the directive to your div elements as an element, attribute, class, or comment:
 
-    <ui-chart="data1"></ui-chart>
-    <div ui-chart="data2"></div>
-    <div class="ui-chart; data3"></div>
-    <!-- directive: ui-chart data4 -->
+    <ui-chart="data1" id="some-id"></ui-chart>
+    <div ui-chart="data2" id="some-id"></div>
+    <div class="ui-chart; data3" id="some-id"></div>
 
-Your data to pass to `$.jqplot` will be the evaluated value of the `ui-chart` attribute, while the options to pass to `$.jqplot` will be the evaluated value of the `chart-options` attribute - the evaluations are done in scope.
+Your data to pass to `$.jqplot` will be the evaluated value of the `ui-chart` attribute, while the options to pass to `$.jqplot` will be the evaluated value of the `chart-options` attribute - the evaluations are done in scope. It is necessary to specify `id` attribute because it will be used by `$.jqplot`. It is possible to pass a function to `chart-click` attribute that will be called after click event on any node in the plot
 
 # Options
 

--- a/src/chart.js
+++ b/src/chart.js
@@ -7,9 +7,14 @@ angular.module('ui.chart', [])
       link: function (scope, elem, attrs) {
         var renderChart = function () {
           var data = scope.$eval(attrs.uiChart);
-          elem.html('');
+
           if (!angular.isArray(data)) {
             return;
+          }
+
+          var id = elem.attr('id');
+          if (angular.isUndefined(id)) {
+              throw 'Invalid ui.graph id attribute';
           }
 
           var opts = {};
@@ -20,7 +25,18 @@ angular.module('ui.chart', [])
             }
           }
 
-          elem.jqplot(data, opts);
+          $(elem).unbind("jqplotDataClick");
+          $.jqplot(id, data, opts).destroy();
+          $(elem).html('');
+          $.jqplot(id, data, opts);
+
+          var click_callback = scope.$eval(attrs.chartClick);
+          if (angular.isFunction(click_callback)) {
+            return $(elem).bind('jqplotDataClick', function(ev, seriesIndex, pointIndex, data) {
+              return click_callback(ev, seriesIndex, pointIndex, data);
+            });
+          }
+          
         };
 
         scope.$watch(attrs.uiChart, function () {


### PR DESCRIPTION
First of all - with the latest version of jqplot this directive is not working for me, because it call $(element).jqplot, but according to official jqplot's documentation there is only one appropriate way - $.jqplot('elemente's id' ....);
Second - I have added chart-click attribute to pass a function that will be called when event 'jqplotDataClick' is fired.
